### PR TITLE
Add required database settings

### DIFF
--- a/docs/admin/installation-guide/installation/Requirements.md
+++ b/docs/admin/installation-guide/installation/Requirements.md
@@ -8,7 +8,7 @@ Make sure all system requirements from http://documents.symbioworld.com are full
 
 * Microsoft SQL Server
 
-For further information about installing MS SQL Server please see here: https://docs.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server?view=sql-server-2014
+For further information about installing MS SQL Server please see here: https://docs.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server?view=sql-server-2016
 
 Additionally Symbio requires the following software which will be automatically installed by the installation script (###LINK###).
 
@@ -18,12 +18,18 @@ Additionally Symbio requires the following software which will be automatically 
 
 For version numbers consult http://documents.symbioworld.com.
 
-The following Symbio services must be installed, either manually or by using the installation script.
+The following Symbio services are recommended but optional only:
 
-* WebJobs Service (http://docs.symbioworld.com/content/Articles/webjobsservice/index.html)
-* Rendering Service (http://docs.symbioworld.com/content/Articles/RenderingService/index.html)
+* ![WebJob Scheduler](../../services/web-jobs-scheduler.md)
+* ![Rendering Service](../../services/rendering-service/installation-scripted.md)
 
 ## User rights
 
 - To install symbio you need a user with the right to install the required software and possibly run powershell as administrator.
-- For the symbio application you need a user, who you can enter into the application pool as the executing user. This user needs rights to the target database server, there he must have the right to create databases.
+- For the symbio application you need a user, who you can enter into the application pool as the executing user. This user needs rights to the target database server including the permission to create databases.
+
+## Database settings
+
+The following database settings are required:
+- ALLOW_SNAPSHOT_ISOLATION ON
+- READ_COMMITTED_SNAPSHOT ON


### PR DESCRIPTION
To avoid Single user issues on database additional settings are required to run Symbio:
    ALLOW_SNAPSHOT_ISOLATION ON, READ_COMMITTED_SNAPSHOT ON
Additional improvements to this page made:
Rendering Service and WebJobScheduler are not mandatory but recommended. Links made relative.