### PR TITLE
Removed the Like reference

### DIFF
--- a/docs/developer/rest-api/how-to/filter.md
+++ b/docs/developer/rest-api/how-to/filter.md
@@ -19,7 +19,6 @@ https://Server/Collection/Database/_api/rest/facets/processes/views/tree/element
 | Name | Syntax | Type | Description | Example |
 |---|---|---|---|---|
 | Equal | Equal | string | The Boolean equality operator. | ?$filter=name Equal string |
-| Like | Like | string | Determines whether a specific character string matches a specified pattern or not. | ?$filter=name Like '%string' or 'string%' or '%string%' |
 
 ### Function Operators
 


### PR DESCRIPTION
Removed reference to the Like operator after the operator has been removed from the code.

[Bug 30543](https://dev.azure.com/pundz/Symbio/_workitems/edit/30543): RestAPI: -Like operator does not work for REST API
