### PR TITLE
Remove a dead link to "Authentication Token IsPermittedEverywhere"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -227,7 +227,6 @@ nav:
         - Storages API: developer/rest-api/overview/storages-api.md
       - How To:
         - Authentication Tokens: developer/rest-api/how-to/rest-symbio-auth-token-client-temp-example-documentation/rest-symbio-auth-token-client-temp-example-documentation.md
-        - Authentication Token IsPermittedEverywhere: developer/is-permitted-everywhere.md
         - How to get all released mainprocesses: developer/rest-api/how-to/quickstart-mainprocesses/quickstart-mainprocesses.md
         - Filter: developer/rest-api/how-to/filter.md
         - Errors: developer/rest-api/how-to/error.md


### PR DESCRIPTION
Apparently the file was removed in https://github.com/ploetz-zeller/symbio-documentation/pull/169.